### PR TITLE
Fix FORTRAN package name in Arch Linux

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -42,7 +42,10 @@ conan_basic_setup()
     def system_requirements(self):
         if os_info.is_linux:
             installer = SystemPackageTool()
-            installer.install("gfortran")
+            if tools.os_info.linux_distro == "arch":
+                installer.install("gcc-fortran")
+            else:
+                installer.install("gfortran")
         if os_info.is_macos:
             installer = SystemPackageTool()
             installer.install("gcc", update=True, force=True)


### PR DESCRIPTION
The FORTRAN package name in Arch is 'gcc-fortran' and not 'gfortran' as in the
recipe.