### PR TITLE
Upgrade faulty system_requirements implementation

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -96,6 +96,30 @@ class LapackConan(ConanFile):
                     self.output.info('renaming %s into %s' % (lib, vslib))
                     shutil.move(lib, vslib)
 
+    def system_requirements(self):
+        installer = SystemPackageTool()
+        if tools.os_info.is_linux and not os.system("which gfortran"):
+            if tools.os_info.with_pacman or \
+                tools.os_info.with_yum:
+                try:
+                    installer.install("gcc-fortran")
+                except:
+                    installer.install("gcc-gfortran")
+            else:
+                installer.install("gfortran")
+                versionfloat = Version(self.settings.compiler.version.value)
+                if self.settings.compiler == "gcc":
+                    if versionfloat < "5.0":
+                        installer.install("libgfortran-{}-dev".format(versionfloat))
+                    else:
+                        installer.install("libgfortran-{}-dev".format(int(versionfloat)))
+        if tools.os_info.is_macos and Version(self.settings.compiler.version.value) > "7.3":
+            try:
+                installer.install("gcc", update=True, force=True)
+            except Exception:
+                self.output.warn("brew install gcc failed. Tying to fix it with 'brew link'")
+                self.run("brew link --overwrite gcc")
+                    
     def package_id(self):
         if self.options.visual_studio:
             self.info.settings.compiler = "Visual Studio"

--- a/conanfile.py
+++ b/conanfile.py
@@ -82,7 +82,7 @@ class LapackConan(ConanFile):
             except Exception:
                 self.output.warn("brew install gcc failed. Tying to fix it with 'brew link'")
                 self.run("brew link --overwrite gcc")
-            
+
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["CMAKE_GNUtoMS"] = self.options.visual_studio
@@ -120,7 +120,7 @@ class LapackConan(ConanFile):
                     vslib = lib[3:-2] + ".lib"
                     self.output.info('renaming %s into %s' % (lib, vslib))
                     shutil.move(lib, vslib)
-                    
+
     def package_id(self):
         if self.options.visual_studio:
             self.info.settings.compiler = "Visual Studio"

--- a/conanfile.py
+++ b/conanfile.py
@@ -58,27 +58,6 @@ class LapackConan(ConanFile):
         if self.settings.os == "Windows":
             self.build_requires("mingw_installer/1.0@conan/stable")
 
-    def system_requirements(self):
-        installer = SystemPackageTool()
-        if tools.os_info.is_linux:
-            if tools.os_info.with_pacman or \
-                tools.os_info.with_yum:
-                installer.install("gcc-fortran")
-            else:
-                installer.install("gfortran")
-                versionfloat = Version(self.settings.compiler.version.value)
-                if self.settings.compiler == "gcc":
-                    if versionfloat < "5.0":
-                        installer.install("libgfortran-{}-dev".format(versionfloat))
-                    else:
-                        installer.install("libgfortran-{}-dev".format(int(versionfloat)))
-        if tools.os_info.is_macos and Version(self.settings.compiler.version.value) > "7.3":
-            try:
-                installer.install("gcc", update=True, force=True)
-            except Exception:
-                self.output.warn("brew install gcc failed. Tying to fix it with 'brew link'")
-                self.run("brew link --overwrite gcc")
-
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["CMAKE_GNUtoMS"] = self.options.visual_studio

--- a/conanfile.py
+++ b/conanfile.py
@@ -58,12 +58,12 @@ class LapackConan(ConanFile):
         if self.settings.os == "Windows":
             self.build_requires("mingw_installer/1.0@conan/stable")
 
-    def system_requirements(self):
+    def system_requirements(self):        
+        if not tools.which("gfortran"):
+            # Prefere local install
+            return
         installer = SystemPackageTool()
         if tools.os_info.is_linux:
-            if not os.system("which gfortran"):
-                # Prefere local install
-                return
             if tools.os_info.with_zypper:
                 # Package for: OpenSUSE
                 installer.install("gcc-fortran")

--- a/conanfile.py
+++ b/conanfile.py
@@ -59,19 +59,19 @@ class LapackConan(ConanFile):
             self.build_requires("mingw_installer/1.0@conan/stable")
 
     def system_requirements(self):        
-        if not tools.which("gfortran"):
+        if tools.which("gfortran") is not None:
             # Prefere local install
             return
         installer = SystemPackageTool()
         if tools.os_info.is_linux:
-            if tools.os_info.with_zypper:
-                # Package for: OpenSUSE
+            if tools.os_info.with_zypper or tools.os_info.with_pacman:
+                # Package for: OpenSUSE, Arch 
                 installer.install("gcc-fortran")
-            elif tools.os_info.with_pacman or tools.os_info.with_yum:
-                # Package for: CentOS, ...
+            elif tools.os_info.with_yum:
+                # Package for: CentOS
                 installer.install("gcc-gfortran")
             else:
-                # Package for: Arch, Ubuntu, ...
+                # Package for: Ubuntu, ...
                 installer.install("gfortran")
                 versionfloat = Version(self.settings.compiler.version.value)
                 if self.settings.compiler == "gcc":

--- a/conanfile.py
+++ b/conanfile.py
@@ -65,13 +65,10 @@ class LapackConan(ConanFile):
         installer = SystemPackageTool()
         if tools.os_info.is_linux:
             if tools.os_info.with_zypper or tools.os_info.with_pacman:
-                # Package for: OpenSUSE, Arch 
                 installer.install("gcc-fortran")
             elif tools.os_info.with_yum:
-                # Package for: CentOS
                 installer.install("gcc-gfortran")
             else:
-                # Package for: Ubuntu, ...
                 installer.install("gfortran")
                 versionfloat = Version(self.settings.compiler.version.value)
                 if self.settings.compiler == "gcc":

--- a/conanfile.py
+++ b/conanfile.py
@@ -62,13 +62,16 @@ class LapackConan(ConanFile):
         installer = SystemPackageTool()
         if tools.os_info.is_linux:
             if not os.system("which gfortran"):
+                # Prefere local install
                 return
-            if tools.os_info.with_pacman or tools.os_info.with_yum:
-                try:
-                    installer.install("gcc-fortran")
-                except:
-                    installer.install("gcc-gfortran")
+            if tools.os_info.with_zypper:
+                # Package for: OpenSUSE
+                installer.install("gcc-fortran")
+            elif tools.os_info.with_pacman or tools.os_info.with_yum:
+                # Package for: CentOS, ...
+                installer.install("gcc-gfortran")
             else:
+                # Package for: Arch, Ubuntu, ...
                 installer.install("gfortran")
                 versionfloat = Version(self.settings.compiler.version.value)
                 if self.settings.compiler == "gcc":


### PR DESCRIPTION
This PR upgrades the faulty system_requirements implementation.

As mentioned in  conan-community/community#302 this type of forced install fails on several popular distributions and does not allow for non-packaged `gfortran` installs.

Both these issues should be resolved with this PR.